### PR TITLE
inheritance tests and package support

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,11 +1,15 @@
 'use strict';
 
+// node built-ins
 var fs         = require('fs');
 var path       = require('path');
 var vm         = require('vm');
 
+// npm modules
 var constants  = require('haraka-constants');
+var config     = require('haraka-config');
 
+// local modules
 var stub       = require('./stub').stub;
 var vm_harness = require('./vm_harness');
 var logger     = require('./logger');
@@ -18,75 +22,118 @@ function Plugin (name) {
     this.name = name;
     this.base = {};
     this.register_hook = stub();
-    this.config = stub();
+    this.plugin_path = this._get_plugin_path();
+    this.config = this._get_config();
     this.last_err = '';
     constants.import(global);
 
     logger.add_log_methods(this, name);
 
-    this.dir_paths = [
-        __dirname + '/../../../plugins/',   // Haraka/plugins/foo
-        __dirname + '../../../',            // npm packaged plugins
-        './',                               // testing
-    ];
-
     return this.load_plugin(name);
 }
 
-Plugin.prototype.get_file_contents = function (name) {
+Plugin.prototype._get_plugin_path = function (name) {
+    var plugin = this;
 
-    // the starting value for __dirname will be the cwd of this module:
-    //    ./node_modules/haraka-test-fixtures/lib
+    plugin.hasPackageJson = false;
+    if (!name) name = plugin.name;
 
-    // the plugin file will be located in one of:
-    //   ./plugins/name.js
-    //   ./name.js                // npm packaged plugin
-    //   ./name-discovered-in-package-json-main-property
+    var paths = [];
 
-    // So, the plugin to be loaded will be found in one of:
-    //    ../../../plugins/name.js
-    //    ../../../name.js
-    //    ../../../name-discovered-in-package-json-main-property
+    if (/node_modules\/haraka\-test\-fixtures\/lib$/.test(__dirname)) {
+        // for Haraka/plugins/*.js && Haraka/node_modules/*
+        var up3 = path.resolve(__dirname, '..', '..', '..');
+        paths.push(
+            path.resolve(up3, 'plugins', name + '.js'),
+            path.resolve(up3, 'plugins', name, 'package.json'),
+            path.resolve(up3, 'node_modules', name, 'package.json')
+        );
+    }
+    else if (/\/lib$/.test(__dirname)) {
+        // for haraka-test-fixture tests
+        paths.push(
+            path.resolve(__dirname, '..', name + '.js'),
+            path.resolve(__dirname, '..', name, 'package.json')
+        );
+    }
+    else if (/\/plugins$/.test(__dirname)) {
+        // for 'inherits' in Haraka/tests/plugins/*.js
+        paths.push(
+            path.resolve(__dirname, name + '.js'),
+            path.resolve(__dirname, name, 'package.json')
+        );
+    }
+    else {
+        // for Haraka/plugins/*.js && Haraka/node_modules/*
+        paths.push(
+            path.resolve(__dirname, 'plugins', name + '.js'),
+            path.resolve(__dirname, 'plugins', name, 'package.json'),
+            path.resolve(__dirname, 'node_modules', name, 'package.json')
+        );
+    }
+    // console.log(paths);
 
-    // plugin tests will be located in one of
-    //   ./tests/plugins/name.js
-    //   ./tests/name.js
-    //   ./test/name.js
+    for (var i = 0; i < paths.length; i++) {
+        var pp = paths[i];
+        try {
+            fs.statSync(pp);
+            if (/\/package\.json$/.test(pp)) {
+                plugin.hasPackageJson = true;
+            }
+            return pp;
+        }
+        catch (ignore) {
+            // console.error(ignore.message);
+        }
+    };
+};
 
-    if (this.plugin_dir) {
-        // this runs when a plugin loads another plugin, such as when
-        // a plugin calls this.inherits();
-        return fs.readFileSync(path.resolve(this.plugin_dir, name + '.js'));
+Plugin.prototype._get_config = function () {
+    if (this.hasPackageJson) {
+        // It's a package/folder plugin - look in plugin folder for defaults,
+        // haraka/config folder for overrides
+        return config.module_config(
+            path.dirname(this.plugin_path),
+            process.env.HARAKA || __dirname
+        );
     }
 
-    if (this.dir_paths.length === 0) {
-        throw "Loading test plugin " + name + " failed: " + this.last_err;
-    }
+    // Plain .js file, git mode - just look in this folder
+    return config.module_config(__dirname);
+};
 
-    var dp = this.dir_paths.shift();
-    this.full_path = path.resolve(dp + name + '.js');
+Plugin.prototype._get_code = function (pi_path) {
+    var plugin = this;
+
+    if (plugin.hasPackageJson) {
+        var ppd = path.dirname(pi_path);
+
+        // this isn't working for haraka-test-fixtures tests. Why?
+        // return 'exports = require("' + ppd + '");';
+
+        // workaround / ugly cheatin hack
+        var js = fs.readFileSync(pi_path);
+        return fs.readFileSync(path.join(ppd, (js.main || 'index.js')));
+    }
 
     try {
-        var content = fs.readFileSync(this.full_path);
-        this.plugin_dir = dp;
-        return content;
+        return '"use strict";' + fs.readFileSync(pi_path);
     }
     catch (err) {
-        // console.error(err.message);
-        this.last_err = err;
-        this.get_file_contents(name);
+        throw 'Loading plugin ' + this.name + ' failed: ' + err;
     }
 }
 
-Plugin.prototype.load_plugin = function (name) {
-    var rf = this.get_file_contents(name);
+Plugin.prototype.load_plugin = function (name, pp) {
 
-    var code = '"use strict";' + rf;
+    if (!pp) pp = this.plugin_path;
+    var code = this._get_code(pp);
+    // console.log(code);
 
     var sandbox = {
         require: vm_harness.sandbox_require,
-        __filename: this.full_path,
-        __dirname:  path.dirname(this.full_path),
+        __filename: pp,
+        __dirname:  path.dirname(pp),
         exports: this,
         console: console,
         setTimeout: setTimeout,
@@ -109,7 +156,8 @@ Plugin.prototype.load_plugin = function (name) {
 };
 
 Plugin.prototype.inherits = function (parent_name) {
-    var parent_plugin = this.load_plugin(parent_name);
+    var parent_path = this._get_plugin_path(parent_name);
+    var parent_plugin = this.load_plugin(parent_name, parent_path);
     for (var method in parent_plugin) {
         if (!this[method]) {
             this[method] = parent_plugin[method];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-test-fixtures",
   "license": "MIT",
   "description": "Haraka Test Fixtures",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "address-rfc2821": "*",
-    "haraka-config": "^1.0.2",
+    "haraka-config": "*",
     "haraka-constants": "*"
   },
   "optionalDependencies": {},

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "address-rfc2821": "*",
+    "haraka-config": "^1.0.2",
     "haraka-constants": "*"
   },
   "optionalDependencies": {},

--- a/test/fixtures/mock-plugin-dir/index.js
+++ b/test/fixtures/mock-plugin-dir/index.js
@@ -1,0 +1,4 @@
+
+exports.register = function () {
+    // console.log('I am a mock plugin dir')
+};

--- a/test/fixtures/mock-plugin-dir/package.json
+++ b/test/fixtures/mock-plugin-dir/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mock-plugin-dir",
+  "version": "1.0.0",
+  "description": "Mock Plugin",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Matt Simerson",
+  "license": "MIT"
+}

--- a/test/fixtures/mock-plugin.js
+++ b/test/fixtures/mock-plugin.js
@@ -1,5 +1,5 @@
 
-
 exports.register = function () {
-
+    // console.log('I am a mock plugin file');
+    this.inherits('mock-plugin-dir');
 };

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -9,11 +9,49 @@ exports.Plugin = {
         test.equal(typeof Plugin, 'function');
         test.done();
     },
-    'creates a new Plugin': function (test) {
+    'creates a new Plugin from .js': function (test) {
         test.expect(1);
         var newPlugin = new Plugin('test/fixtures/mock-plugin');
         // console.log(newPlugin);
         test.ok(newPlugin);
+        test.done();
+    },
+    'creates a new Plugin from dir': function (test) {
+        test.expect(1);
+        var newPlugin = new Plugin('test/fixtures/mock-plugin-dir');
+        // console.log(newPlugin);
+        test.ok(newPlugin);
+        test.done();
+    },
+}
+
+exports.contents = {
+    setUp: function (done) {
+        // console.log(Plugin);
+        this.plugin = new Plugin('test/fixtures/mock-plugin-dir');
+        done();
+    },
+    'register exists': function (test) {
+        test.expect(1);
+        // console.log(this.plugin);
+        test.equal(typeof this.plugin.register, 'function');
+        test.done();
+    },
+    'register runs': function (test) {
+        test.expect(1);
+        this.plugin.register();
+        test.ok(true); // register() didn't throw
+        test.done();
+    }
+}
+
+exports.inherits = {
+    'can register plugin with ineritance': function (test) {
+        test.expect(2);
+        var pi = new Plugin('test/fixtures/mock-plugin');
+        test.equal(typeof pi.register, 'function');
+        pi.register();
+        test.ok(Object.keys(pi.base));
         test.done();
     },
 }


### PR DESCRIPTION
* import _get_plugin_path, for improved module path resolution
    * add name argument, and return path (vs setting this.plugin_path), so inherits() can use it
* search other paths, under special conditions
    * such as: tests for test fixtures (a new thing)
* refactored some logic into _get_code