### PR TITLE
update result_store, adding get(plugin) syntax.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,7 @@
 
+# 1.0.15 - Jan 24, 2017
+    * update result_store, adding get(plugin) syntax.
+
 # 1.0.14 - Jan 24, 2017
     * add path for npm packaged plugin inheriting an npm packaged plugin
 

--- a/lib/result_store.js
+++ b/lib/result_store.js
@@ -126,10 +126,9 @@ ResultStore.prototype.collate = function (plugin) {
     return this.private_collate(result, name).join(', ');
 };
 
-ResultStore.prototype.get = function (plugin_name) {
-    var result = this.store[plugin_name];
-    if (!result) return;
-    return result;
+ResultStore.prototype.get = function (plugin_or_name) {
+    var name = this.resolve_plugin_name(plugin_or_name);
+    return this.store[name];
 };
 
 ResultStore.prototype.resolve_plugin_name = function (thing) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-test-fixtures",
   "license": "MIT",
   "description": "Haraka Test Fixtures",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",

--- a/test/result_store.js
+++ b/test/result_store.js
@@ -2,18 +2,14 @@
 var Connection   = require('../lib/connection');
 var ResultStore  = require('../lib/result_store');
 
-function _set_up(callback) {
+function _set_up(done) {
     this.connection = Connection.createConnection();
     this.connection.results = new ResultStore(this.connection);
-    callback();
-}
-function _tear_down(callback) {
-    callback();
+    done();
 }
 
 exports.default_result = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'init add' : function (test) {
         test.expect(1);
         this.connection.results.add('test_plugin', { pass: 'test pass' });
@@ -88,8 +84,6 @@ exports.default_result = {
 
 exports.has = {
     setUp : _set_up,
-    tearDown : _tear_down,
-    /* jshint maxlen: 100 */
     'has, list, string' : function (test) {
         test.expect(2);
         this.connection.results.add('test_plugin', { pass: 'test pass' });
@@ -138,13 +132,33 @@ exports.has = {
 
 exports.private_collate = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'collate, arrays are shown in output' : function (test) {
         test.expect(2);
         this.connection.results.push('test_plugin', { foo: 'bar' });
         // console.log(this.connection.results);
         test.equal(true, this.connection.results.has('test_plugin', 'foo', /bar/));
         test.ok(/bar/.test(this.connection.results.get('test_plugin').human));
+        test.done();
+    },
+};
+
+exports.get = {
+    setUp : function (done) {
+		this.connection = Connection.createConnection();
+		this.connection.results = new ResultStore(this.connection);
+        this.connection.results.add('test_plugin', { pass: 'foo' });
+        done();
+    },
+    'has, plugin' : function (test) {
+        test.expect(1);
+        var cr = this.connection.results.get({ name: 'test_plugin' });
+        test.equal('foo', cr.pass[0]);
+        test.done();
+    },
+    'has, plugin name' : function (test) {
+        test.expect(1);
+        var cr = this.connection.results.get('test_plugin');
+        test.equal('foo', cr.pass[0]);
         test.done();
     },
 };


### PR DESCRIPTION
I keep trying to `results.get(plugin)` and it doesn't work because unlike the other result store functions, which accept either a plugin name or plugin, `get()` was a special little unicorn. No more.