### PR TITLE
a few little fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- doc(README): update example to use node:test imports and scoped let
+- fix(connection): return → continue in setTLS() loop
+- fix(connection): guarded server.address() with typeof + fallback
+- fix(plugin): removed redundant _compile()
+- fix(plugin): `"use strict";\n` so trailing // comments in plugin files can't swallow the rest
+- fix(plugin): escape " in packageDir before interpolation (after the Windows backslash escape)
+
 ### [1.6.0] - 2026-05-17
 
 - feat(dns): add configurable DNS server fixture (`fixtures.dns`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - doc(README): update example to use node:test imports and scoped let
 - fix(connection): return → continue in setTLS() loop
 - fix(connection): guarded server.address() with typeof + fallback
-- fix(plugin): removed redundant _compile()
+- fix(plugin): removed redundant \_compile()
 - fix(plugin): `"use strict";\n` so trailing // comments in plugin files can't swallow the rest
 - fix(plugin): escape " in packageDir before interpolation (after the Windows backslash escape)
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,20 @@ const fixtures = require('haraka-test-fixtures')
 ### A common pattern
 
 ```js
-beforeEach(() => {
-  this.plugin = new fixtures.plugin('pluginName')
-
-  this.connection = fixtures.connection.createConnection()
-  this.connection.init_transaction()
-})
+const { beforeEach, describe, it } = require('node:test')
 
 describe('pluginName', () => {
+  let plugin
+  let connection
+
+  beforeEach(() => {
+    plugin = new fixtures.plugin('pluginName')
+    connection = fixtures.connection.createConnection()
+    connection.init_transaction()
+  })
+
   it('registers', () => {
-    this.plugin.register()
+    plugin.register()
   })
 })
 ```

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -110,8 +110,10 @@ class Connection {
       return
     }
 
-    const local_addr =
-      (typeof self.server.address === 'function' && self.server.address()) || { address: '127.0.0.1', port: 25 }
+    const local_addr = (typeof self.server.address === 'function' && self.server.address()) || {
+      address: '127.0.0.1',
+      port: 25,
+    }
     self.set('local', 'ip', ipaddr.process(self.client.localAddress || local_addr.address).toString())
     self.set('local', 'port', self.client.localPort || local_addr.port)
     self.results.add({ name: 'local' }, self.local)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -110,7 +110,8 @@ class Connection {
       return
     }
 
-    const local_addr = self.server.address()
+    const local_addr =
+      (typeof self.server.address === 'function' && self.server.address()) || { address: '127.0.0.1', port: 25 }
     self.set('local', 'ip', ipaddr.process(self.client.localAddress || local_addr.address).toString())
     self.set('local', 'port', self.client.localPort || local_addr.port)
     self.results.add({ name: 'local' }, self.local)
@@ -175,7 +176,7 @@ class Connection {
     this.set('hello', 'host', undefined)
     this.set('tls', 'enabled', true)
     for (const t of ['cipher', 'verified', 'verifyError', 'peerCertificate']) {
-      if (obj[t] === undefined) return
+      if (obj[t] === undefined) continue
       this.set('tls', t, obj[t])
     }
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -33,8 +33,6 @@ class Plugin {
     constants.import(global)
 
     logger.add_log_methods(this, name)
-
-    this._compile()
   }
 
   register() {
@@ -177,12 +175,14 @@ class Plugin {
         // escape the c:\path\back\slashes else they disappear
         packageDir = packageDir.replace(/\\/g, '\\\\')
       }
+      // escape quotes to prevent string-literal breakouts from unusual paths
+      packageDir = packageDir.replace(/"/g, '\\"')
 
       return `var _p = require("${packageDir}"); for (var k in _p) { exports[k] = _p[k] }`
     }
 
     try {
-      return `"use strict";${fs.readFileSync(pi_path)}`
+      return `"use strict";\n${fs.readFileSync(pi_path)}`
     } catch (err) {
       throw `Loading plugin ${this.name} failed: ${err}`
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier:fix": "npx prettier . --write --log-level=warn",
     "test": "node --test test/*.js",
     "test:coverage": "node --test --experimental-test-coverage test/*.js",
-    "test:coverage:lcov": "npx c8 --reporter=text --reporter=text-summary npm test",
+    "test:coverage:lcov": "mkdir -p coverage && node --test --test-concurrency=1 --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info",
     "versions": "npx npm-dep-mgr check",
     "versions:fix": "npx npm-dep-mgr update"
   },


### PR DESCRIPTION
- doc(README): update example to use node:test imports and scoped let
- fix(connection): return → continue in setTLS() loop
- fix(connection): guarded server.address() with typeof + fallback
- fix(plugin): removed redundant _compile()
- fix(plugin): `"use strict";\n` so trailing // comments in plugin files can't swallow the rest
- fix(plugin): escape " in packageDir before interpolation (after the Windows backslash escape)